### PR TITLE
Optimize implementation to try to eliminate warnings about blocking

### DIFF
--- a/components/winix_c545/winix_c545.cpp
+++ b/components/winix_c545/winix_c545.cpp
@@ -94,7 +94,7 @@ void WinixC545Component::update_state_(const WinixStateMap &states) {
   }
 }
 
-void WinixC545Component::parse_aws_sentence_(const char *sentence) {
+void WinixC545Component::parse_aws_sentence_(char *sentence) {
   uint16_t api_code = 0;
   if (sscanf(sentence, "AWS_SEND=A%3d", &api_code) != 1) {
     ESP_LOGE(TAG, "Failed to extract API code from sentence: %s", sentence);
@@ -121,15 +121,14 @@ void WinixC545Component::parse_aws_sentence_(const char *sentence) {
     {
       ESP_LOGI(TAG, "State update: %s", sentence);
 
-      // Create a modifiable copy of the message payload for tokenization
-      char payload[MAX_LINE_LENGTH];
-      strcpy(payload, sentence + strlen("AWS_SEND=A2XX {"));
+      // Advance sentence to first token
+      sentence += strlen("AWS_SEND=A2XX {");
 
       // Construct map to hold updates
       WinixStateMap states;
 
       // Parse each token into a KV pair
-      char *token = strtok(payload, ",");
+      char *token = strtok(sentence, ",");
       while (token != NULL) {
         char key[4] = {0};
         uint32_t value = 0;
@@ -174,7 +173,7 @@ void WinixC545Component::parse_aws_sentence_(const char *sentence) {
   }
 }
 
-void WinixC545Component::parse_sentence_(const char *sentence) {
+void WinixC545Component::parse_sentence_(char *sentence) {
   ESP_LOGD(TAG, "Received sentence: %s", sentence);
 
   // Example sentence formats

--- a/components/winix_c545/winix_c545.cpp
+++ b/components/winix_c545/winix_c545.cpp
@@ -315,6 +315,7 @@ void WinixC545Component::loop() {
 
     // Line received, parse it
     this->parse_sentence_(buffer);
+    return;
   }
 }
 

--- a/components/winix_c545/winix_c545.cpp
+++ b/components/winix_c545/winix_c545.cpp
@@ -397,12 +397,15 @@ void WinixC545Component::loop() {
   // Publish states as needed
   this->publish_state_();
 
-  if (this->available() < RX_PREFIX.size()) return;
+  // Return if no data available
+  if (!this->available())
+    return;
 
+  // Read all available data until the first sentence is received
   while (this->available() > 0) {
-    char data = this->read();
-    bool found = this->readline_(data, buffer, MAX_LINE_LENGTH);
-    if (!found) continue;
+    bool found = this->readline_(this->read(), buffer, MAX_LINE_LENGTH);
+    if (!found)
+      continue;
 
     // Line received, parse it
     this->parse_sentence_(buffer);

--- a/components/winix_c545/winix_c545.cpp
+++ b/components/winix_c545/winix_c545.cpp
@@ -246,17 +246,16 @@ bool WinixC545Component::readline_(char data, char *buffer, int max_length) {
     case '\n':  // Ignore new-lines
       break;
 
-    case '\r': {  // Return on CR
-      int end = position;
-      position = 0;  // Reset position index ready for next time
-      return end;
+    case '\r': {             // Return on CR
+      buffer[position] = 0;  // Ensure buffer is null terminated
+      position = 0;          // Reset position for next line
+      return true;
     }
 
     default:
-      if (position < max_length - 1) {
+      if (position < max_length - 1)
         buffer[position++] = data;
-        buffer[position] = 0;
-      }
+
       break;
   }
 

--- a/components/winix_c545/winix_c545.cpp
+++ b/components/winix_c545/winix_c545.cpp
@@ -20,17 +20,22 @@ void WinixC545Component::write_sentence_(const std::string &sentence) {
 }
 
 void WinixC545Component::write_state(const WinixStateMap &states) {
+  constexpr uint32_t BUFFER_SIZE = 16;
+
   // Nothing to do if empty
   if (states.empty())
     return;
 
   std::string sentence = "AWS_RECV:A211 12 {";
 
+  // Reserve storage for each possible state
+  sentence.reserve(states.size() * BUFFER_SIZE);
+
   for (const auto &state : states) {
     const std::string &key = state.first;
     const uint16_t value = state.second;
 
-    char buffer[16];
+    char buffer[BUFFER_SIZE];
     snprintf(buffer, sizeof(buffer), "\"%s\":\"%d\",", key.c_str(), value);
 
     sentence.append(buffer);

--- a/components/winix_c545/winix_c545.cpp
+++ b/components/winix_c545/winix_c545.cpp
@@ -211,8 +211,6 @@ void WinixC545Component::parse_aws_sentence_(char *sentence) {
     case 210:  // Overall device state
     case 220:  // Sensor update
     {
-      ESP_LOGI(TAG, "State update: %s", sentence);
-
       // Advance sentence to first token
       sentence += strlen("AWS_SEND=A2XX {");
 

--- a/components/winix_c545/winix_c545.cpp
+++ b/components/winix_c545/winix_c545.cpp
@@ -11,12 +11,12 @@ namespace winix_c545 {
 static const char *const TAG = "winix_c545";
 
 void WinixC545Component::write_sentence_(const std::string &sentence) {
-  // Build complete command sentence
-  std::string tx_data = TX_PREFIX + sentence + "\r\n";
+  ESP_LOGD(TAG, "Sending sentence: %s%s", TX_PREFIX.c_str(), sentence.c_str());
 
   // Send over UART
-  ESP_LOGD(TAG, "Sending sentence: %s", tx_data.c_str());
-  this->write_str(tx_data.c_str());
+  this->write_str(TX_PREFIX.c_str());
+  this->write_str(sentence.c_str());
+  this->write_str("\r\n");
 }
 
 void WinixC545Component::write_state(const WinixStateMap &states) {

--- a/components/winix_c545/winix_c545.cpp
+++ b/components/winix_c545/winix_c545.cpp
@@ -30,7 +30,7 @@ void WinixC545Component::write_state(const WinixStateMap &states) {
     const std::string &key = state.first;
     const uint16_t value = state.second;
 
-    char buffer[32] = {0};
+    char buffer[16];
     snprintf(buffer, sizeof(buffer), "\"%s\":\"%d\",", key.c_str(), value);
 
     sentence += std::string(buffer);

--- a/components/winix_c545/winix_c545.cpp
+++ b/components/winix_c545/winix_c545.cpp
@@ -33,7 +33,7 @@ void WinixC545Component::write_state(const WinixStateMap &states) {
     char buffer[16];
     snprintf(buffer, sizeof(buffer), "\"%s\":\"%d\",", key.c_str(), value);
 
-    sentence += std::string(buffer);
+    sentence.append(buffer);
   }
 
   // Remove final comma and insert end brace

--- a/components/winix_c545/winix_c545.cpp
+++ b/components/winix_c545/winix_c545.cpp
@@ -118,8 +118,8 @@ void WinixC545Component::parse_aws_sentence_(const char *sentence) {
       ESP_LOGI(TAG, "State update: %s", sentence);
 
       // Create a modifiable copy of the message payload for tokenization
-      char payload[MAX_LINE_LENGTH] = {0};
-      strncpy(payload, sentence + strlen("AWS_SEND=A2XX {"), MAX_LINE_LENGTH);
+      char payload[MAX_LINE_LENGTH];
+      strcpy(payload, sentence + strlen("AWS_SEND=A2XX {"));
 
       // Construct map to hold updates
       WinixStateMap states;

--- a/components/winix_c545/winix_c545.cpp
+++ b/components/winix_c545/winix_c545.cpp
@@ -41,9 +41,8 @@ void WinixC545Component::write_state(const WinixStateMap &states) {
     sentence.append(buffer);
   }
 
-  // Remove final comma and insert end brace
-  sentence.pop_back();
-  sentence += "}";
+  // Replace final comma with an end brace
+  sentence.at(sentence.size() - 1) = '}';
 
   // Write sentence to device
   this->write_sentence_(sentence);

--- a/components/winix_c545/winix_c545.cpp
+++ b/components/winix_c545/winix_c545.cpp
@@ -83,46 +83,90 @@ void WinixC545Component::publish_state_() {
     const uint16_t value = state.second;
 
     // Handle sensor states and other non-fan states
-    if (key == StateKey::AQIIndicator && this->aqi_indicator_text_sensor_ != nullptr) {
-      // AQI LED indicator
-      switch (value) {
-        case 1:
-          this->aqi_indicator_text_sensor_->publish_state("Good");
-          break;
-        case 2:
-          this->aqi_indicator_text_sensor_->publish_state("Fair");
-          break;
-        case 3:
-          this->aqi_indicator_text_sensor_->publish_state("Poor");
-          break;
+    switch (key) {
+      case StateKey::AQIIndicator: {
+        // AQI LED indicator
+
+        if (this->aqi_indicator_text_sensor_ == nullptr)
+          continue;
+
+        switch (value) {
+          case 1:
+            this->aqi_indicator_text_sensor_->publish_state("Good");
+            break;
+          case 2:
+            this->aqi_indicator_text_sensor_->publish_state("Fair");
+            break;
+          case 3:
+            this->aqi_indicator_text_sensor_->publish_state("Poor");
+            break;
+        }
+
+        break;
       }
-    } else if (key == StateKey::AQI && this->aqi_sensor_ != nullptr) {
-      // AQI
-      if (value != this->aqi_sensor_->raw_state)
-        this->aqi_sensor_->publish_state(value);
-    } else if (key == StateKey::Light && this->light_sensor_ != nullptr) {
-      // Light
-      if (value != this->light_sensor_->raw_state)
-        this->light_sensor_->publish_state(value);
-    } else if (key == StateKey::FilterAge && this->filter_age_sensor_ != nullptr) {
-      // Filter age
-      if (value != this->filter_age_sensor_->raw_state)
-        this->filter_age_sensor_->publish_state(value);
-    } else if (key == StateKey::Plasmawave && this->plasmawave_switch_ != nullptr) {
-      // Plasmawave
-      bool state = value == 1;
-      if (state != this->plasmawave_switch_->state)
-        this->plasmawave_switch_->publish_state(state);
-    } else if (key == StateKey::Auto && this->auto_switch_ != nullptr) {
-      // Auto
-      bool state = value == 1;
-      if (state != this->auto_switch_->state)
-        this->auto_switch_->publish_state(state);
-    } else if (key == StateKey::Speed && this->sleep_switch_ != nullptr) {
-      // Sleep is a speed value
-      bool state = value == 6;
-      if (state != this->sleep_switch_->state)
-        this->sleep_switch_->publish_state(state);
+
+      case StateKey::AQI: {
+        // AQI
+        if (this->aqi_sensor_ == nullptr)
+          continue;
+
+        if (value != this->aqi_sensor_->raw_state)
+          this->aqi_sensor_->publish_state(value);
+        break;
+      }
+
+      case StateKey::Light: {
+        // Light
+        if (this->light_sensor_ == nullptr)
+          continue;
+
+        if (value != this->light_sensor_->raw_state)
+          this->light_sensor_->publish_state(value);
+        break;
+      }
+
+      case StateKey::FilterAge: {
+        // Filter age
+        if (this->filter_age_sensor_ == nullptr)
+          continue;
+
+        if (value != this->filter_age_sensor_->raw_state)
+          this->filter_age_sensor_->publish_state(value);
+        break;
+      }
+
+      case StateKey::Plasmawave: {
+        // Plasmawave
+        if (this->plasmawave_switch_ == nullptr)
+          continue;
+
+        bool state = value == 1;
+        if (state != this->plasmawave_switch_->state)
+          this->plasmawave_switch_->publish_state(state);
+        break;
+      }
+
+      case StateKey::Auto: {
+        // Auto
+        if (this->auto_switch_ == nullptr)
+          continue;
+
+        bool state = value == 1;
+        if (state != this->auto_switch_->state)
+          this->auto_switch_->publish_state(state);
+        break;
+      }
+
+      case StateKey::Speed: {
+        // Sleep is a speed value
+        if (this->sleep_switch_ == nullptr)
+          continue;
+
+        bool state = value == 6;
+        if (state != this->sleep_switch_->state)
+          this->sleep_switch_->publish_state(state);
+        break;
+      }
     }
   }
 
@@ -415,28 +459,39 @@ void WinixC545Fan::update_state(const WinixStateMap &states) {
     const uint16_t value = state.second;
 
     // Handle fan states
-    if (key == StateKey::Power) {
-      // Power on/off
-      bool state = value == 1 ? true : false;
-      if (state != this->state) {
+    switch (key) {
+      case StateKey::Power: {
+        // Power on/off
+        bool state = (value == 1) ? true : false;
+
+        if (state == this->state)
+          continue;
+
         // State has changed, publish
         this->state = state;
         publish = true;
-      }
-    } else if (key == StateKey::Speed) {
-      uint8_t speed = 0;
-      // Speed
-      if (value == 5)  // Turbo
-        speed = 4;
-      else if (value == 6)  // Sleep
-        speed = 0;          // TODO?
-      else
-        speed = value;
 
-      if (speed != this->speed) {
+        break;
+      }
+
+      case StateKey::Speed: {
+        // Speed
+        uint8_t speed = 0;
+        if (value == 5)  // Turbo
+          speed = 4;
+        else if (value == 6)  // Sleep
+          speed = 0;          // TODO?
+        else
+          speed = value;
+
+        if (speed == this->speed)
+          continue;
+
         // Speed has changed, publish
         this->speed = speed;
         publish = true;
+
+        break;
       }
     }
   }

--- a/components/winix_c545/winix_c545.cpp
+++ b/components/winix_c545/winix_c545.cpp
@@ -90,6 +90,13 @@ void WinixC545Component::publish_state_() {
         if (this->aqi_indicator_text_sensor_ == nullptr)
           continue;
 
+        // No change in raw indicator value
+        if (value == this->aqi_indicator_raw_value_)
+          continue;
+
+        // Save raw value for intelligent publishing of sensor
+        this->aqi_indicator_raw_value_ = value;
+
         switch (value) {
           case 1:
             this->aqi_indicator_text_sensor_->publish_state("Good");

--- a/components/winix_c545/winix_c545.h
+++ b/components/winix_c545/winix_c545.h
@@ -84,11 +84,13 @@ class WinixC545Component : public uart::UARTDevice, public Component {
   HandshakeState handshake_state_{HandshakeState::Reset};
   uint32_t last_handshake_event_ = 0;
 
+  WinixStateMap states_;
+
   void update_handshake_state_();
   bool readline_(char, char *, int);
   void parse_sentence_(char *);
   void parse_aws_sentence_(char *);
-  void update_state_(const WinixStateMap &);
+  void publish_state_();
   void write_sentence_(const std::string &);
 
 #ifdef USE_FAN

--- a/components/winix_c545/winix_c545.h
+++ b/components/winix_c545/winix_c545.h
@@ -102,6 +102,7 @@ class WinixC545Component : public uart::UARTDevice, public Component {
   uint32_t last_handshake_event_ = 0;
 
   WinixStateMap states_;
+  uint32_t aqi_indicator_raw_value_ = 0;
 
   void update_handshake_state_();
   bool readline_(char, char *, int);

--- a/components/winix_c545/winix_c545.h
+++ b/components/winix_c545/winix_c545.h
@@ -86,8 +86,8 @@ class WinixC545Component : public uart::UARTDevice, public Component {
 
   void update_handshake_state_();
   bool readline_(char, char *, int);
-  void parse_sentence_(const char *);
-  void parse_aws_sentence_(const char *);
+  void parse_sentence_(char *);
+  void parse_aws_sentence_(char *);
   void update_state_(const WinixStateMap &);
   void write_sentence_(const std::string &);
 

--- a/components/winix_c545/winix_c545.h
+++ b/components/winix_c545/winix_c545.h
@@ -71,7 +71,7 @@ class WinixC545Component : public uart::UARTDevice, public Component {
   const std::string RX_PREFIX{"AT*ICT*"};
   const std::string TX_PREFIX{"*ICT*"};
 
-  static constexpr uint32_t MAX_LINE_LENGTH = 255;
+  static constexpr uint32_t MAX_LINE_LENGTH = 128;
 
   enum class HandshakeState {
     Reset,


### PR DESCRIPTION
- Parse single sentences at a time
- Publish states separately from sentence reception
- Only publish changed states
- Use enums for keys to reduce the number of string comparisons
- Remove zero-initialization of buffers
- Tokenize the sentence in place
- Reduce buffer sizes
- Preallocate strings when possible and perform in-place edits

Current warnings are

> [21:42:22][W][component:214]: Component winix_c545 took a long time for an operation (0.15 s).
> [21:42:22][W][component:215]: Components should block for at most 20-30ms.

with these changes it's reduced by about half

> [22:03:05][W][component:214]: Component winix_c545 took a long time for an operation (0.08 s).
> [22:03:05][W][component:215]: Components should block for at most 20-30ms.

Close #1