### PR TITLE
Add support for the AP handshake so fresh devices can be used

### DIFF
--- a/components/winix_c545/winix_c545.cpp
+++ b/components/winix_c545/winix_c545.cpp
@@ -368,6 +368,17 @@ void WinixC545Component::update_handshake_state_() {
       this->write_sentence_("AWS_IND:CONNECT OK");
       break;
     }
+
+    default: {
+      // If in an intermediate state and no activity occurs for a while reset the state machine
+      if ((millis() - this->last_handshake_event_) < 10000)
+        return;
+
+      // Reset handshake state
+      ESP_LOGW(TAG, "Handshake stalled in state %d. Restarting.", this->handshake_state_);
+      this->handshake_state_ = HandshakeState::Reset;
+      break;
+    }
   }
 }
 

--- a/components/winix_c545/winix_c545.h
+++ b/components/winix_c545/winix_c545.h
@@ -93,9 +93,13 @@ class WinixC545Component : public uart::UARTDevice, public Component {
   enum class HandshakeState {
     Reset,
     DeviceReady,
-    MIB,
     McuReady,
+    MIB,
     Connected,
+    ApReboot,
+    ApDeviceReady,
+    ApStart,
+    ApStop,
   };
 
   HandshakeState handshake_state_{HandshakeState::Reset};


### PR DESCRIPTION
As seen in #9 a device that has never been "provisioned" by the OEM app will always try to enter AP mode and ignore the normal handshake protocol.

This PR adds support for the AP handshake so a user can use this component on a fresh device. Or if the user accidentally enters AP mode the component will be able to perform the proper handshake