### PR TITLE
Add fan speed as an optional sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An ESPHome component for the Winix C545 air purifier.
 ## Features
 - Full local control of the air purifier via Home Assistant or MQTT.
 - Physical device controls remain functional and changes are immediately reflected in the frontend. 
-- AQI, AQI indicator, filter age, filter lifetime and light intensity sensors.
+- AQI, AQI indicator, filter age, filter lifetime, light intensity and fan speed sensors.
 - Switch to control Plasmawave.
 - Auto and Sleep modes are implemented as fan presets.
 - Piggybacks on the OEM protocol with minimal hardware modifications required.
@@ -99,6 +99,8 @@ sensor:
       name: AQI
     light:
       name: Light Intensity
+    fan_speed:
+      name: Fan Speed
 
 text_sensor:
   - platform: winix_c545

--- a/components/winix_c545/sensor.py
+++ b/components/winix_c545/sensor.py
@@ -13,6 +13,7 @@ CONF_AQI = "aqi"
 CONF_FILTER_AGE = "filter_age"
 CONF_FILTER_LIFETIME = "filter_lifetime"
 CONF_LIGHT = "light"
+CONF_FAN_SPEED = "fan_speed"
 
 CONFIG_SCHEMA = cv.Schema(
     {
@@ -41,6 +42,11 @@ CONFIG_SCHEMA = cv.Schema(
             unit_of_measurement=UNIT_EMPTY,
             accuracy_decimals=0,
             state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_FAN_SPEED): sensor.sensor_schema(
+            unit_of_measurement=UNIT_EMPTY,
+            accuracy_decimals=0,
+            state_class=STATE_CLASS_MEASUREMENT,
         )
     }
 )
@@ -64,3 +70,7 @@ async def to_code(config) -> None:
     if sensor_config := config.get(CONF_LIGHT):
         sens = await sensor.new_sensor(sensor_config)
         cg.add(component.set_light_sensor(sens))
+
+    if sensor_config := config.get(CONF_FAN_SPEED):
+        sens = await sensor.new_sensor(sensor_config)
+        cg.add(component.set_fan_speed_sensor(sens))

--- a/components/winix_c545/winix_c545.cpp
+++ b/components/winix_c545/winix_c545.cpp
@@ -462,7 +462,7 @@ void WinixC545Component::dump_config() {
   LOG_SENSOR("  ", "Filter Lifetime Sensor", this->filter_lifetime_sensor_);
   LOG_SENSOR("  ", "AQI Sensor", this->aqi_sensor_);
   LOG_SENSOR("  ", "Light Sensor", this->light_sensor_);
-  LOG_SNESOR("  ", "Fan Speed Sensor", this->fan_speed_sensor_);
+  LOG_SENSOR("  ", "Fan Speed Sensor", this->fan_speed_sensor_);
 #endif
 
 #ifdef USE_TEXT_SENSOR

--- a/components/winix_c545/winix_c545.cpp
+++ b/components/winix_c545/winix_c545.cpp
@@ -169,6 +169,14 @@ void WinixC545Component::publish_state_() {
   // Pass states to underlying fan if it exists
   if (this->fan_ != nullptr) {
     this->fan_->update_state(this->states_);
+
+    // Publish the fan speed sensor if configured
+    if (this->fan_speed_sensor_ != nullptr)
+    {
+      auto value = this->fan_->speed;
+      if (value != this->fan_speed_sensor_->raw_state)
+        this->fan_speed_sensor_->publish_state(value);
+    }
   }
 
   // All states published, clear contents
@@ -455,6 +463,7 @@ void WinixC545Component::dump_config() {
   LOG_SENSOR("  ", "Filter Lifetime Sensor", this->filter_lifetime_sensor_);
   LOG_SENSOR("  ", "AQI Sensor", this->aqi_sensor_);
   LOG_SENSOR("  ", "Light Sensor", this->light_sensor_);
+  LOG_SNESOR("  ", "Fan Speed Sensor", this->fan_speed_sensor_);
 #endif
 
 #ifdef USE_TEXT_SENSOR

--- a/components/winix_c545/winix_c545.cpp
+++ b/components/winix_c545/winix_c545.cpp
@@ -171,8 +171,7 @@ void WinixC545Component::publish_state_() {
     this->fan_->update_state(this->states_);
 
     // Publish the fan speed sensor if configured
-    if (this->fan_speed_sensor_ != nullptr)
-    {
+    if (this->fan_speed_sensor_ != nullptr) {
       auto value = this->fan_->speed;
       if (value != this->fan_speed_sensor_->raw_state)
         this->fan_speed_sensor_->publish_state(value);

--- a/components/winix_c545/winix_c545.h
+++ b/components/winix_c545/winix_c545.h
@@ -60,6 +60,7 @@ class WinixC545Component : public uart::UARTDevice, public Component {
   SUB_SENSOR(filter_lifetime)
   SUB_SENSOR(aqi)
   SUB_SENSOR(light)
+  SUB_SENSOR(fan_speed)
 #endif
 
 #ifdef USE_TEXT_SENSOR

--- a/example.yaml
+++ b/example.yaml
@@ -43,6 +43,8 @@ sensor:
       name: AQI
     light:
       name: Light Intensity
+    fan_speed:
+      name: Fan Speed
 
   - platform: template
     name: Filter Lifetime


### PR DESCRIPTION
Although HA knows the fan speed it doesn't appear to make the speed available in the history or logbook.

This adds a new subsensor for fan speed so it's state can be tracked by HA