### PR TITLE
Update component for ESPHome 2025.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An ESPHome component for the Winix C545 air purifier.
 - ESP32
   - ESP8266 may work but lacks a free [hardware UART](https://esphome.io/components/uart.html#hardware-uarts).
   - A [Raspberry Pi Pico W](docs/example_pico-w.yaml) has also been used successfully.
-- ESPHome 2023.10 or above
+- ESPHome 2025.11 or above
   - Older versions may function but have not been tested.
 - A bi-directional logic level shifter. 
   - Pictured here is the Adafruit TXB0104 Bi-Directional Level Shifter.

--- a/components/winix_c545/winix_c545.h
+++ b/components/winix_c545/winix_c545.h
@@ -140,7 +140,7 @@ class WinixC545Fan : public fan::Fan, public Parented<WinixC545Component> {
   static constexpr const char *const PRESET_SLEEP = "Sleep";
   static constexpr const char *const PRESET_AUTO = "Auto";
 
-  bool presets_equal_(const char* preset_a, const char* preset_b) {
+  bool presets_equal_(const char *preset_a, const char *preset_b) {
     if (preset_a == nullptr || preset_b == nullptr)
       return false;
 

--- a/components/winix_c545/winix_c545.h
+++ b/components/winix_c545/winix_c545.h
@@ -136,9 +136,16 @@ class WinixC545Fan : public fan::Fan, public Parented<WinixC545Component> {
   void update_state(const WinixStateMap &);
 
  protected:
-  const std::string PRESET_NONE{""};
-  const std::string PRESET_SLEEP{"Sleep"};
-  const std::string PRESET_AUTO{"Auto"};
+  static constexpr const char *const PRESET_NONE = "";
+  static constexpr const char *const PRESET_SLEEP = "Sleep";
+  static constexpr const char *const PRESET_AUTO = "Auto";
+
+  bool presets_equal_(const char* preset_a, const char* preset_b) {
+    if (preset_a == nullptr || preset_b == nullptr)
+      return false;
+
+    return strcmp(preset_a, preset_b) == 0;
+  }
 
   void control(const fan::FanCall &call) override;
   fan::FanTraits traits_;


### PR DESCRIPTION
ESPHome made breaking changes to preset_mode. It is no longer public and should be access via get_preset_mode and set_preset_mode