### PR TITLE
fix preset modes not showing in HA

### DIFF
--- a/components/winix_c545/winix_c545.h
+++ b/components/winix_c545/winix_c545.h
@@ -131,7 +131,10 @@ class WinixC545Fan : public fan::Fan, public Parented<WinixC545Component> {
     this->set_supported_preset_modes({PRESET_AUTO, PRESET_SLEEP});
   }
 
-  fan::FanTraits get_traits() override { return this->traits_; }
+  fan::FanTraits get_traits() override {
+    this->wire_preset_modes_(this->traits_);
+    return this->traits_;
+  }
 
   void dump_config();
   void update_state(const WinixStateMap &);


### PR DESCRIPTION
I noticed my preset actions were no longer working in HA. I believe this started after ESPHome 2026.5, though I'm not entirely sure. Currently running ESPHome 2026.6.2. 

This change fixed preset modes for me.

related to https://github.com/mill1000/esphome-winix-c545/issues/29